### PR TITLE
Added FontAwesome Icon Support for TopLevel Headlines

### DIFF
--- a/models/Submenu.php
+++ b/models/Submenu.php
@@ -78,8 +78,12 @@ Class Gecka_Submenu_Submenu {
     		$auto_title = isset($instance['auto_title']) && $instance['auto_title'] ? true : false;
     		
     		$title = '';
+    		$before_icon = '';
     		if( $auto_title &&  $this->top_level_item) {
     			$title = $this->top_level_item->title;
+    			if(strlen($this->top_level_item->description) > 0 && strpos($this->top_level_item->description, 'fa-') !== false){
+                    $before_icon = '<span><i class="fa ' . $this->top_level_item->description . ' fa-2x"></i></span>';
+                }
     		}
     		else $title = $instance['title'];
        
@@ -88,7 +92,7 @@ Class Gecka_Submenu_Submenu {
     		echo $before_widget;
 
     		if($title) {
-    			echo $before_title . apply_filters('widget_title', $title, $instance) . $after_title;
+    			echo $before_title . $before_icon . apply_filters('widget_title', $title, $instance) . $after_title;
     		}
     		 
     		echo $out;


### PR DESCRIPTION
Under Menus in WP add description field to your top level menu item
with the fontawesome fa-icon css class name. The $before_icon will be added to the $before_title string.
